### PR TITLE
Updated to Java 16

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,5 +24,12 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: 'adopt'
 
+    - name: Cache Maven packages
+      uses: actions/cache@v2.1.5
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,7 @@ jobs:
     
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 16]
 
     steps:
     - name: Checkout Repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     
+    # For Minecraft 1.8-1.12.2, Java 8 is the recommended version.
+    # For Minecraft 1.13-1.16.5, Java 11 is the recommended version.
+    # And for Minecraft 1.17, Java 16 is the version that we should use
     strategy:
       matrix:
         java: [8, 11, 16]

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,10 +88,10 @@
             <id>placeholderapi</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
-		<repository>
-			<id>sonatype-oss-snapshots</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</repository>
+	<repository>
+	    <id>sonatype-oss-snapshots</id>
+	    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+	</repository>
     </repositories>
 
     <dependencies>
@@ -123,7 +123,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.16.5-R0.1-SNAPSHOT</version>
@@ -136,7 +135,6 @@
             <version>1.0</version>
             <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>org.bryangaming.chatlab</groupId>
             <artifactId>chatlab-versions-legacyversion</artifactId>


### PR DESCRIPTION
Java 16 will be standard as of Minecraft 1.17 https://www.minecraft.net/en-us/article/minecraft-snapshot-21w19a
And added Cache Actions to have faster tests and to avoid errors in obtaining dependencies.